### PR TITLE
Clear interval on window load to prevent loop

### DIFF
--- a/content.js
+++ b/content.js
@@ -75,6 +75,9 @@ function ApplyAntigram() {
 
 }
 
-// We call the function periodically and after a delay to let the components load.
-// TO DO: think for a more efficient way to do this.
-setInterval(ApplyAntigram, 1000); 
+let applyCallInterval = setInterval(ApplyAntigram, 500); 
+
+window.addEventListener('load', () => {
+    ApplyAntigram();
+    clearInterval(applyCallInterval);
+});


### PR DESCRIPTION
Calls for Apply function every 500ms until window loaded. Not worrying about interval clear on settings changed as there's a listener on localStorage changed. Fixes #3.