### PR TITLE
Automatic Build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,25 +15,27 @@ jobs:
 
       - name: Install Google Chrome
         run: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo dpkg -i google-chrome-stable_current_amd64.deb
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo dpkg -i google-chrome-stable_current_amd64.deb
 
       - name: Build CRX
         run: |
-            google-chrome-stable --pack-extension="./source"
-            mv ./source.crx ./antigram.crx
+          google-chrome-stable --pack-extension="./source"
+          mv ./source.crx ./antigram.crx
 
       - name: Build Zip
         run: |
-            mkdir antigram
-            cp -r ./source/* ./antigram
-            zip -r antigram.zip ./antigram
+          mkdir antigram
+          cp -r ./source/* ./antigram
+          zip -r antigram.zip ./antigram
 
       - name: Release
         uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
             files: |
-                ./antigram.crx
-                ./antigram.zip
+              ./antigram.crx
+              ./antigram.zip
+            tag_name: 
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  workflow_dispatch: 
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Google Chrome
+        run: |
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo dpkg -i google-chrome-stable_current_amd64.deb
+
+      - name: Build CRX
+        run: |
+            google-chrome-stable --pack-extension="./source"
+            mv ./source.crx ./antigram.crx
+
+      - name: Build Zip
+        run: |
+            mkdir antigram
+            cp -r ./source/* ./antigram
+            zip -r antigram.zip ./antigram
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+            files: |
+                ./antigram.crx
+                ./antigram.zip
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -2,7 +2,7 @@
   "name": "Antigram - Explore & Reels Blocker",
   "description": "Browser extension to fight back Instagram's addictive features.",
   "author": "aymyo",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "manifest_version": 3,
 
   "permissions": ["storage"],


### PR DESCRIPTION
Hello!

I made a build and publish GitHub action to create .crx and .zip files to make the installation process easier!

When you create a new tag release, the process will automatically make a release like this:
https://github.com/ArthurLobopro/antigram-extension/releases/tag/v2.0.2

So you only need to write the release notes and the user will be able do download the .zip version or the .crx version with just a click!

 I hope it can be helpful.