### PR TITLE
Add option to make website grayscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Antigram is a browser extension that gives the user tools to fight back Instagram's addictive
 features. It was made on my free time with the objective of being able to check what were my friends
-up to without falling into a blackhole of meaningless content.
+up to without falling into a black hole of meaningless content.
 
 ### ✨  Current features
 
@@ -13,15 +13,16 @@ up to without falling into a blackhole of meaningless content.
 - Block 'Suggested followers' section
 - Block 'Threads' links
 - Redirect 'For You' feed to 'Following' to avoid suggested posts
+- Make website grayscale 
   
 Missing something? Leave me a [suggestion](https://github.com/aymyo/antigram-extension/issues)! ☀️
 
 ### 📀  Stack
-To avoid a build process and make development easier, I've sticked to browser native functionalities and JS, HTML and CSS.
+To avoid a build process and make development easier, I've stickied to browser native functionalities and JS, HTML and CSS.
 
 ### ⏬  Set it up in your browser
 
-Download it from the [Chrome Store](https://chrome.google.com/webstore/detail/antigram-explore-blocker/igbheapdmolhhmmklmkfjjjncmhihfjh "Chrome Store") or install it mmanually follwing the next steps:
+Download it from the [Chrome Store](https://chrome.google.com/webstore/detail/antigram-explore-blocker/igbheapdmolhhmmklmkfjjjncmhihfjh "Chrome Store") or install it manually following the next steps:
 
 1. Clone the repo, `git clone https://github.com/aymyo/antigram-extension.git` or download the zip.
 2. Go to Google Chrome and click 'Customize' (the three-dot icon top-right corner)
@@ -32,10 +33,10 @@ Download it from the [Chrome Store](https://chrome.google.com/webstore/detail/an
 7. Done!
 
 #### Disclaimer
-Instragam updates periodically its web version, potentially breaking some functionalities of the extension. If that happens, please ensure you are using the last version of Antigram, and if that's the case, open an [issue](https://github.com/aymyo/antigram-extension/issues) so I can fix it! 🛠️
+Instagram updates periodically its web version, potentially breaking some functionalities of the extension. If that happens, please ensure you are using the last version of Antigram, and if that's the case, open an [issue](https://github.com/aymyo/antigram-extension/issues) so I can fix it! 🛠️
 
 ### 💌 Support it
-Antigram is free and open-source and will always be. If you found it useful, please consider [donating](https://ko-fi.com/aymyo) to make the mantainance and improvement possible :)
+Antigram is free and open-source and will always be. If you found it useful, please consider [donating](https://ko-fi.com/aymyo) to make the maintenance and improvement possible :)
 
 ### 🤝 Contributing
 If you want to contribute please feel free to do so by opening a PR. I will review it at some point (although I can't promise that happens soon!).
@@ -51,8 +52,8 @@ To start developing, do steps 1-7 and:
 This extension is mostly inspired by Jord West's
 [News Feed Eradicator](https://github.com/jordwest/news-feed-eradicator), which I recommend if you
 are a Facebook user. Additionally, I also recommend
-[DF Youtube](https://chrome.google.com/webstore/detail/df-tube-distraction-free/mjdepdfccjgcndkmemponafgioodelna)
-to have a better experience using Youtube.
+[DF YouTube](https://chrome.google.com/webstore/detail/df-tube-distraction-free/mjdepdfccjgcndkmemponafgioodelna)
+to have a better experience using YouTube.
 
 
 [logo]: https://github.com/aymyo/antigram-extension/blob/main/source/public/ag32.png "Antigram Logo"

--- a/source-firefox/modules/lib.js
+++ b/source-firefox/modules/lib.js
@@ -6,6 +6,7 @@ export const defaultOptions = {
   blockSuggestedFollowers: true,
   blockForYouFeed: true,
   blockThreads: true,
+  grayscaleWebsite: false,
 };
 
 export const labelsArray = Object.keys(defaultOptions);

--- a/source-firefox/modules/main.js
+++ b/source-firefox/modules/main.js
@@ -16,6 +16,15 @@ async function main() {
   function onMutation() {
     const path = window.location.pathname;
     const body = document.body;
+    const html = document.documentElement;
+
+    if (settings.grayscaleWebsite) {
+      html.style.filter = "grayscale(100%)";
+      html.style.webkitFilter = "grayscale(100%)";
+    } else {
+      html.style.filter = "";
+      html.style.webkitFilter = "";
+    }
   
     if(settings.blockThreads) {
       const threadLinks = body?.querySelectorAll(selectors.nav.threads);

--- a/source-firefox/popup/popup.html
+++ b/source-firefox/popup/popup.html
@@ -38,6 +38,12 @@
               Hide 'Suggested followers' section
             </label>
 
+            <h2 class="pt-3">Appearance</h2>
+            <p>Change how Instagram looks.</p>
+            <label>
+              <input type="checkbox" id="grayscaleWebsite" /> Make website grayscale
+            </label>
+
             <h2 class="pt-3">Redirect</h2>
             <p>If enabled, will always show the 'Following' feed, avoiding suggested content.</p>
             <label>

--- a/source/modules/lib.js
+++ b/source/modules/lib.js
@@ -6,6 +6,7 @@ export const defaultOptions = {
   blockSuggestedFollowers: true,
   blockForYouFeed: true,
   blockThreads: true,
+  grayscaleWebsite: false,
 };
 
 export const labelsArray = Object.keys(defaultOptions);

--- a/source/modules/main.js
+++ b/source/modules/main.js
@@ -16,6 +16,15 @@ async function main() {
   function onMutation() {
     const path = window.location.pathname;
     const body = document.body;
+    const html = document.documentElement;
+
+    if (settings.grayscaleWebsite) {
+      html.style.filter = "grayscale(100%)";
+      html.style.webkitFilter = "grayscale(100%)";
+    } else {
+      html.style.filter = "";
+      html.style.webkitFilter = "";
+    }
   
     if(settings.blockThreads) {
       const threadLinks = body?.querySelectorAll(selectors.nav.threads);

--- a/source/popup/popup.html
+++ b/source/popup/popup.html
@@ -38,6 +38,12 @@
               Hide 'Suggested followers' section
             </label>
 
+            <h2 class="pt-3">Appearance</h2>
+            <p>Change how Instagram looks.</p>
+            <label>
+              <input type="checkbox" id="grayscaleWebsite" /> Make website grayscale
+            </label>
+
             <h2 class="pt-3">Redirect</h2>
             <p>If enabled, will always show the 'Following' feed, avoiding suggested content.</p>
             <label>


### PR DESCRIPTION
This pull request introduces a new feature that allows users to make the Instagram website grayscale, enhancing the extension's customization options. It also includes several minor improvements and typo corrections in the documentation.

**New Feature: Appearance Customization**

* Added a "Make website grayscale" option to the extension settings, allowing users to toggle grayscale mode for Instagram. This includes:
  - New `grayscaleWebsite` setting in `defaultOptions` in both `source/modules/lib.js` and `source-firefox/modules/lib.js`.
  - UI update in `popup.html` (for both Chrome and Firefox) to include the new appearance section and grayscale toggle.
  - Logic in `main.js` (for both Chrome and Firefox) to apply or remove grayscale filter on the website based on the setting.

**Documentation and Copy Improvements**

* Updated the `README.md` with the new grayscale feature, fixed typos, and improved clarity in several sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R39) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R56)

Resolves https://github.com/aymyo/antigram-extension/issues/79