### PR TITLE
Fix [cropped About tab] & Feat [Select all toggle]

### DIFF
--- a/source-firefox/popup/popup.css
+++ b/source-firefox/popup/popup.css
@@ -22,11 +22,12 @@ a {
 }
 
 .antigram {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   background: var(--gray);
   color: var(--white);
-  min-width: 40ch;
+  min-width: 42ch;
   width: 40ch;
   max-height: 600px;
   display: flex;
@@ -36,6 +37,14 @@ a {
   flex-direction: column;
   overflow: hidden;
   border-radius: 0.5rem;
+}
+
+/* Let tall tabs (e.g. About) scroll instead of being clipped by max-height,
+   while the header stays fixed. */
+main {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .text-antigram {
@@ -62,6 +71,15 @@ input[type="checkbox"] {
   accent-color: var(--red);
   transform: scale(1.1);
   margin-right: 0.5rem;
+}
+
+/* Master "Select all" toggle: same row style as the options, set apart with a
+   divider and slightly bolder text. */
+.select-all {
+  font-weight: 600;
+  border-radius: 0;
+  margin-bottom: 0.3rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 [data-tab-content] {

--- a/source-firefox/popup/popup.html
+++ b/source-firefox/popup/popup.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Antigram Options</title>
     <link
       rel="stylesheet"
@@ -14,7 +15,7 @@
 
   <body class="antigram">
     <div class="d-flex align-items-center py-3 px-4 gap-2 border-bottom">
-      <img width="26" height="26" src="../public/ag48.png" />
+      <img width="26" height="26" src="../public/ag48.png" alt="Antigram logo" />
       <h1 class="text-antigram m-0 fs-3 mb-1">Antigram</h1>
       <nav class="d-flex gap-3 mb-0 p-0 mt-0 ms-auto">
         <a data-tab-target="#options" class="active" href="#">Options</a>
@@ -28,15 +29,20 @@
           <h2>Hide</h2>
           <form class="fw-light">
             <p class="fw-light">Block the sections you don't want to see.</p>
-            <label><input type="checkbox" id="blockReels" /> Hide 'Reels' page </label>
-            <label><input type="checkbox" id="blockExplore" /> Hide 'Explore' page </label>
-            <label><input type="checkbox" id="blockStories" /> Hide 'Stories' section </label>
-            <label><input type="checkbox" id="blockPosts" /> Hide 'Posts' section </label>
-            <label><input type="checkbox" id="blockThreads" /> Hide 'Threads' links </label>
-            <label>
-              <input type="checkbox" id="blockSuggestedFollowers" />
-              Hide 'Suggested followers' section
+            <label class="select-all"
+              ><input type="checkbox" id="selectAllHide" /> Select all
             </label>
+            <div id="hideGroup">
+              <label><input type="checkbox" id="blockReels" /> Hide 'Reels' page </label>
+              <label><input type="checkbox" id="blockExplore" /> Hide 'Explore' page </label>
+              <label><input type="checkbox" id="blockStories" /> Hide 'Stories' section </label>
+              <label><input type="checkbox" id="blockPosts" /> Hide 'Posts' section </label>
+              <label><input type="checkbox" id="blockThreads" /> Hide 'Threads' links </label>
+              <label>
+                <input type="checkbox" id="blockSuggestedFollowers" />
+                Hide 'Suggested followers' section
+              </label>
+            </div>
 
             <h2 class="pt-3">Redirect</h2>
             <p>If enabled, will always show the 'Following' feed, avoiding suggested content.</p>

--- a/source-firefox/popup/popup.js
+++ b/source-firefox/popup/popup.js
@@ -29,8 +29,26 @@ const restoreOptions = () => {
     for (const key of Object.keys(items)) {
       document.getElementById(key).checked = items[key];
     }
+    syncSelectAll();
   });
 };
+
+// "Select all" toggle for the Hide section. It mirrors the group's checkboxes
+// (checked when all are on, half-state when only some are) and is a UI helper
+// only — it is not one of the saved options.
+const selectAllHide = document.getElementById("selectAllHide");
+const hideChecks = Array.from(document.querySelectorAll("#hideGroup input[type=checkbox]"));
+
+const syncSelectAll = () => {
+  const checkedCount = hideChecks.filter((checkbox) => checkbox.checked).length;
+  selectAllHide.checked = checkedCount === hideChecks.length;
+  selectAllHide.indeterminate = checkedCount > 0 && checkedCount < hideChecks.length;
+};
+
+selectAllHide.addEventListener("change", () => {
+  hideChecks.forEach((checkbox) => (checkbox.checked = selectAllHide.checked));
+});
+hideChecks.forEach((checkbox) => checkbox.addEventListener("change", syncSelectAll));
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.getElementById("save").addEventListener("click", saveOptions);

--- a/source/popup/popup.css
+++ b/source/popup/popup.css
@@ -22,11 +22,12 @@ a {
 }
 
 .antigram {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   background: var(--gray);
   color: var(--white);
-  min-width: 40ch;
+  min-width: 42ch;
   width: 40ch;
   max-height: 600px;
   display: flex;
@@ -36,6 +37,14 @@ a {
   flex-direction: column;
   overflow: hidden;
   border-radius: 0.5rem;
+}
+
+/* Let tall tabs (e.g. About) scroll instead of being clipped by max-height,
+   while the header stays fixed. */
+main {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .text-antigram {
@@ -62,6 +71,15 @@ input[type="checkbox"] {
   accent-color: var(--red);
   transform: scale(1.1);
   margin-right: 0.5rem;
+}
+
+/* Master "Select all" toggle: same row style as the options, set apart with a
+   divider and slightly bolder text. */
+.select-all {
+  font-weight: 600;
+  border-radius: 0;
+  margin-bottom: 0.3rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 [data-tab-content] {

--- a/source/popup/popup.html
+++ b/source/popup/popup.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Antigram Options</title>
     <link
       rel="stylesheet"
@@ -14,7 +15,7 @@
 
   <body class="antigram">
     <div class="d-flex align-items-center py-3 px-4 gap-2 border-bottom">
-      <img width="26" height="26" src="../public/ag48.png" />
+      <img width="26" height="26" src="../public/ag48.png" alt="Antigram logo" />
       <h1 class="text-antigram m-0 fs-3 mb-1">Antigram</h1>
       <nav class="d-flex gap-3 mb-0 p-0 mt-0 ms-auto">
         <a data-tab-target="#options" class="active" href="#">Options</a>
@@ -28,15 +29,20 @@
           <h2>Hide</h2>
           <form class="fw-light">
             <p class="fw-light">Block the sections you don't want to see.</p>
-            <label><input type="checkbox" id="blockReels" /> Hide 'Reels' page </label>
-            <label><input type="checkbox" id="blockExplore" /> Hide 'Explore' page </label>
-            <label><input type="checkbox" id="blockStories" /> Hide 'Stories' section </label>
-            <label><input type="checkbox" id="blockPosts" /> Hide 'Posts' section </label>
-            <label><input type="checkbox" id="blockThreads" /> Hide 'Threads' links </label>
-            <label>
-              <input type="checkbox" id="blockSuggestedFollowers" />
-              Hide 'Suggested followers' section
+            <label class="select-all"
+              ><input type="checkbox" id="selectAllHide" /> Select all
             </label>
+            <div id="hideGroup">
+              <label><input type="checkbox" id="blockReels" /> Hide 'Reels' page </label>
+              <label><input type="checkbox" id="blockExplore" /> Hide 'Explore' page </label>
+              <label><input type="checkbox" id="blockStories" /> Hide 'Stories' section </label>
+              <label><input type="checkbox" id="blockPosts" /> Hide 'Posts' section </label>
+              <label><input type="checkbox" id="blockThreads" /> Hide 'Threads' links </label>
+              <label>
+                <input type="checkbox" id="blockSuggestedFollowers" />
+                Hide 'Suggested followers' section
+              </label>
+            </div>
 
             <h2 class="pt-3">Redirect</h2>
             <p>If enabled, will always show the 'Following' feed, avoiding suggested content.</p>

--- a/source/popup/popup.js
+++ b/source/popup/popup.js
@@ -29,8 +29,26 @@ const restoreOptions = () => {
     for (const key of Object.keys(items)) {
       document.getElementById(key).checked = items[key];
     }
+    syncSelectAll();
   });
 };
+
+// "Select all" toggle for the Hide section. It mirrors the group's checkboxes
+// (checked when all are on, half-state when only some are) and is a UI helper
+// only — it is not one of the saved options.
+const selectAllHide = document.getElementById("selectAllHide");
+const hideChecks = Array.from(document.querySelectorAll("#hideGroup input[type=checkbox]"));
+
+const syncSelectAll = () => {
+  const checkedCount = hideChecks.filter((checkbox) => checkbox.checked).length;
+  selectAllHide.checked = checkedCount === hideChecks.length;
+  selectAllHide.indeterminate = checkedCount > 0 && checkedCount < hideChecks.length;
+};
+
+selectAllHide.addEventListener("change", () => {
+  hideChecks.forEach((checkbox) => (checkbox.checked = selectAllHide.checked));
+});
+hideChecks.forEach((checkbox) => checkbox.addEventListener("change", syncSelectAll));
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.getElementById("save").addEventListener("click", saveOptions);


### PR DESCRIPTION
## 🐛 Fix — About tab was being cropped

**Problem**
- Opening the **About** tab cut off its content. The popup's `max-height` combined with `overflow: hidden` clipped anything taller than the popup, with no way to scroll.
- See screenshots below.

**Fix**
- The `<main>` content area now scrolls while the header stays fixed, so the full About content is reachable.
- Also resolved the popup's HTML validation warnings: `lang` on `<html>`, `alt` on the logo `<img>`, and a `viewport` meta tag.

## ✨ Feature — "Select all" for the Hide section

- New **Select all** toggle at the top of the Hide list.
- Checks / unchecks all six Hide options at once.
- Shows a half (indeterminate) state when only some are selected.
- Styled to match the existing rows, set apart with a divider.
- UI helper only — not saved as an option, and does not affect the Redirect setting.

## 🏷️ Type

`fix` · `feat` · `enhancement`

## 🧪 Testing

- Tested by loading the extension in both **Chrome** and **Firefox**:
  - About tab scrolls fully — no cropping.
  - Select all toggles all Hide rows; half-state shows when only some are ticked.
  - Save still persists across reopen.
- Prettier-clean per the repo config.

## 📝 Notes

- Applied to both `source` (Chrome) and `source-firefox` (Firefox); popup-only changes — no manifest, permissions, or behavior changes.
- No version bump or README edit — left to your discretion on release.

## 📸 Screenshots

**Before — About tab cropped**

<img width="349" height="600" alt="image" src="https://github.com/user-attachments/assets/8465eefa-649d-4f57-8923-16d329701acb" />


**After — About tab scrolls**

<img width="398" height="712" alt="image" src="https://github.com/user-attachments/assets/bcfda068-93f5-4f17-a69a-350b3d3dbd1c" />
